### PR TITLE
Abstract out console log messages for iOS

### DIFF
--- a/Lawnchair-adapter/Lawnchair-sqlitePlugin.js
+++ b/Lawnchair-adapter/Lawnchair-sqlitePlugin.js
@@ -1,6 +1,6 @@
 Lawnchair.adapter('webkit-sqlite', (function () {
     // private methods 
-    var fail = function (e, i) { console.log('error in sqlite adaptor!', e, i) }
+    var fail = function (e, i) { sqlitePlugin.log('error in sqlite adaptor: ' + e.message) }
     ,   now  = function () { return new Date() } // FIXME need to use better date fn
 	// not entirely sure if this is needed...
     if (!Function.prototype.bind) {

--- a/Lawnchair-adapter/test-www/Lawnchair-sqlitePlugin.js
+++ b/Lawnchair-adapter/test-www/Lawnchair-sqlitePlugin.js
@@ -1,6 +1,6 @@
 Lawnchair.adapter('webkit-sqlite', (function () {
     // private methods 
-    var fail = function (e, i) { console.log('error in sqlite adaptor!', e, i) }
+    var fail = function (e, i) { sqlitePlugin.log('error in sqlite adaptor: ' + e.message) }
     ,   now  = function () { return new Date() } // FIXME need to use better date fn
 	// not entirely sure if this is needed...
     if (!Function.prototype.bind) {

--- a/iOS/Plugins/SQLitePlugin.h
+++ b/iOS/Plugins/SQLitePlugin.h
@@ -22,6 +22,12 @@
 #import "CDVFile.h"
 #endif
 
+#ifdef DEBUG
+#   define DLog(fmt, ...) NSLog((@"%s [Line %d] " fmt), __PRETTY_FUNCTION__, __LINE__, ##__VA_ARGS__);
+#else
+#   define DLog(...)
+#endif
+
 #import "AppDelegate.h"
 
 @interface SQLitePlugin : CDVPlugin {
@@ -31,6 +37,7 @@
 @property (nonatomic, copy) NSMutableDictionary *openDBs;
 @property (nonatomic, retain) NSString *appDocsPath;
 
+-(void) log:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options;
 -(void) open:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options;
 -(void) backgroundExecuteSqlBatch:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options;
 -(void) backgroundExecuteSql:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options;

--- a/iOS/Plugins/SQLitePlugin.m
+++ b/iOS/Plugins/SQLitePlugin.m
@@ -30,7 +30,7 @@
         // Make Cordova 1.6 compatible
         //[self setAppDocsPath:[NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) objectAtIndex: 0]];
         NSString *docs = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) objectAtIndex: 0];
-        NSLog(@"Detected docs path: %@", docs);
+        DLog(@"Detected docs path: %@", docs);
         [self setAppDocsPath:docs];
     }
     return self;
@@ -51,6 +51,11 @@
     return dbPath;
 }
 
+-(void) log: (NSMutableArray*)arguments withDict:(NSMutableDictionary*)options
+{
+	DLog(@"%@", [options objectForKey:@"msg"]);
+}
+
 -(void) open: (NSMutableArray*)arguments withDict:(NSMutableDictionary*)options
 {
     NSString *callback = [options objectForKey:@"callback"];
@@ -64,7 +69,7 @@
     sqlite3 *db;
     const char *path = [dbPath UTF8String];
 
-    NSLog(@"using dbPath: %@", dbPath);
+    DLog(@"using dbPath: %@", dbPath);
 
     if (sqlite3_open(path, &db) != SQLITE_OK) {
         [self respond:callback withString:@"{ message: 'Unable to open DB' }" withType:@"error"];

--- a/iOS/www/SQLitePlugin.js
+++ b/iOS/www/SQLitePlugin.js
@@ -50,10 +50,10 @@ if (!window.Cordova) window.Cordova = window.cordova;
       throw new Error("Cannot create a SQLitePlugin instance without a dbPath");
     }
     this.openSuccess || (this.openSuccess = function() {
-      console.log("DB opened: " + dbPath);
+			this.log("DB opened: " + dbPath);
     });
     this.openError || (this.openError = function(e) {
-      console.log(e.message);
+			this.log(e.message);
     });
     this.open(this.openSuccess, this.openError);
   };
@@ -101,6 +101,9 @@ if (!window.Cordova) window.Cordova = window.cordova;
       Cordova.exec("SQLitePlugin.close", opts);
     }
   };
+  SQLitePlugin.prototype.log = function(msg) {
+	  Cordova.exec("SQLitePlugin.log", {msg: msg});
+	}
   SQLitePluginTransaction = function(dbPath) {
     this.dbPath = dbPath;
     this.executes = [];


### PR DESCRIPTION
Apple does not like and has rejected apps, solely based on console
logging.  For the sake of not having to alter the code every time and
for beginners, I suggest that we make it only log if in debug mode.  I
have not done this for the Android version, but this would probably be
just a useful.
